### PR TITLE
chore: Link to my own site for funding options

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: AverageHelper # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: "https://average.name/support" # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
I've moved away from GitHub Sponsors. I've listed my support options on my own site, and TIL that GitHub lets me list a custom URL! Gonna do that.